### PR TITLE
Keep reference to original constants loaded from the JSON.

### DIFF
--- a/lib/json_constants_parser.js
+++ b/lib/json_constants_parser.js
@@ -198,6 +198,7 @@ var parseConstants = function(LJMJSONFileLocation) {
 	var indexedConstants = reindexConstantsByRegister(constantsData);
 	this.constantsByRegister = indexedConstants[0];
 	this.constantsByName = indexedConstants[1];
+	this.origConstants = constantsData;
 
 	//console.log("JSON-CONSTANTS-PARSER");
 	this.getAddressInfo = function(address, direction)


### PR DESCRIPTION
Keep reference to original constants loaded from the JSON.

Keep a reference to the original modbus map constants loaded from
the json file when using json_constants_parser.getConstants.
